### PR TITLE
Add Heatshield to Mk1-2 Pod dynamically

### DIFF
--- a/GameData/VenStockRevamp/DeadlyReentry-Patches.cfg
+++ b/GameData/VenStockRevamp/DeadlyReentry-Patches.cfg
@@ -1,31 +1,32 @@
-@PART[Mark1-2Pod]:NEEDS[DeadlyReentry] {
-	@mass = 4.06
-	@cost = 3877
-	@entryCost = 8200
-	@maxTemp = 1450
-	
-	%MODULE[ModuleHeatShield] {
-	direction = 0, -1, 0
-		reflective = 0.05
-		ablative = AblativeShielding
-		conductivity = 0.01
+@PART[Mark1-2Pod]:NEEDS[DeadlyReentry]:HAS[!MODULE[ModuleHeatShield]]:FINAL
+{
+	@mass += #$@PART[2.5_Heatshield]/mass$
+	@cost += #$@PART[2.5_Heatshield]/cost$
+	@entryCost += #$@PART[2.5_Heatshield]/entryCost$
+	@maxTemp = #$@PART[2.5_Heatshield]/maxTemp$
+
+	%MODULE[ModuleHeatShield]
+	{
+		direction = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/direction$
+		reflective = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/reflective$
+		ablative = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/ablative$
+		conductivity = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/conductivity$
 		loss
 		{
-			key = 650 0 0 0 // start ablating at 650 degrees C
-			key = 1000 320 0 0 // peak ablation at 1000 degrees C
-			key = 3000 400 0 0 // max ablation at 3000 degrees C
+			key,0 = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/loss/key,0$ // start ablating at 650 degrees C
+			key,1 = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/loss/key,1$ // peak ablation at 1000 degrees C
+			key,2 = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/loss/key,2$ // max ablation at 3000 degrees C
 		}
 		dissipation
 		{
-				key = 300 0 0 0
-				key = 500 90 0 0
-		}
+			key,0 = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/dissipation/key,0$
+			key,1 = #$@PART[2.5_Heatshield]/MODULE[ModuleHeatShield]/dissipation/key,1$
+        }
 	}
-	RESOURCE
+	%RESOURCE[AblativeShielding]
 	{
-		name = AblativeShielding
-		amount = 1000
-		maxAmount = 1000
+		%amount = #$@PART[2.5_Heatshield]/RESOURCE[AblativeShielding]/amount$
+        %maxAmount = #$@PART[2.5_Heatshield]/RESOURCE[AblativeShielding]/maxAmount$
 	}
 }
 
@@ -132,7 +133,7 @@
 		name = ModuleHeatShield
 		direction = 0, 0, 0 // full-surface coating
 		reflective = 0.1
-	}	
+	}
 	MODULE:
 	{
     	name = ModuleAnimation2Value


### PR DESCRIPTION
A suggestion for a more safe way to avoid interacting with other mods which change values of the 2.5m Heatshield or the Mark1-2 Pod (like RealismOverhaul for example).
The :HAS[!MODULE[ModuleHeatShield]] might not be necessary in any case.