### PR TITLE
Fix MODULE[TRReflection] nodes being overridden by other mods

### DIFF
--- a/GameData/VenStockRevamp/PartRevamp_TextureReplacer.cfg
+++ b/GameData/VenStockRevamp/PartRevamp_TextureReplacer.cfg
@@ -1,4 +1,5 @@
-@PART[Mark1-2Pod]:NEEDS[TextureReplacer] {
+@PART[Mark1-2Pod]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -6,7 +7,8 @@
         meshes = windows
       }
 }
-@PART[Mark1Cockpit]:NEEDS[TextureReplacer] {
+@PART[Mark1Cockpit]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -14,7 +16,8 @@
         meshes = Shine
       }
 }
-@PART[mk1pod]:NEEDS[TextureReplacer] {
+@PART[mk1pod]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -22,7 +25,8 @@
         meshes = Shine
       }
 }
-@PART[crewCabin]:NEEDS[TextureReplacer] {
+@PART[crewCabin]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -30,7 +34,8 @@
         meshes = Reflect2 Reflect1
       }
 }
-@PART[Large_Crewed_Lab]:NEEDS[TextureReplacer] {
+@PART[Large_Crewed_Lab]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -38,7 +43,8 @@
         meshes = Shine
       }
 }
-@PART[radialRCSTank]:NEEDS[TextureReplacer] {
+@PART[radialRCSTank]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -46,7 +52,8 @@
         meshes = RadialRCS
       }
 }
-@PART[rcsTankRadialLong]:NEEDS[TextureReplacer] {
+@PART[rcsTankRadialLong]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -55,7 +62,8 @@
       }
 }
 
-@PART[RadialLF]:NEEDS[TextureReplacer] {
+@PART[RadialLF]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -63,7 +71,8 @@
         meshes = RadialLF
       }
 }
-@PART[RadialLFLong]:NEEDS[TextureReplacer] {
+@PART[RadialLFLong]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -71,7 +80,8 @@
         meshes = LongRadialLF
       }
 }
-@PART[RadialLFO]:NEEDS[TextureReplacer] {
+@PART[RadialLFO]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -79,7 +89,8 @@
         meshes = RadialLFO
       }
 }
-@PART[RadialLFOLong]:NEEDS[TextureReplacer] {
+@PART[RadialLFOLong]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -87,7 +98,8 @@
         meshes = LongRadialLFO
       }
 }
-@PART[RadialMonoMini]:NEEDS[TextureReplacer] {
+@PART[RadialMonoMini]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -95,7 +107,8 @@
         meshes = MiniRadialRCS
       }
 }
-@PART[solarPanels1]:NEEDS[TextureReplacer] {
+@PART[solarPanels1]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour =  0.3 0.3 0.3
@@ -103,7 +116,8 @@
 		meshes = Cube_003 Cube_002 Cube_004
       }
 }
-@PART[solarPanels2]:NEEDS[TextureReplacer] {
+@PART[solarPanels2]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -111,7 +125,8 @@
 		meshes = Panel1_001 Panel1_002 Panel1_003 Panel1_004 Panel1_005
       }
 }
-@PART[solarPanels3]:NEEDS[TextureReplacer] {
+@PART[solarPanels3]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -119,7 +134,8 @@
 		meshes = Panel1_002 Panel1_001 Panel1_000
       }
 }
-@PART[solarPanels4]:NEEDS[TextureReplacer] {
+@PART[solarPanels4]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -127,22 +143,16 @@
 		meshes = Panel1_002 Panel1_001 Panel1_004 Panel1_003 PanelReflect4_001
       }
 }
-@PART[solarPanels5]:NEEDS[TextureReplacer] {
+@PART[solarPanels5]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
 		interval = 2
       }
 }
-@PART[1x3WPanels]:NEEDS[TextureReplacer] {
-	%MODULE[TRReflection]
-      {
-        colour = 0.3 0.3 0.3
-		interval = 2
-		meshes = Panel1_002 Panel1_001 Panel1_004
-      }
-}
-@PART[1x3SPanels]:NEEDS[TextureReplacer] {
+@PART[1x3WPanels]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -150,7 +160,17 @@
 		meshes = Panel1_002 Panel1_001 Panel1_004
       }
 }
-@PART[largeSolarPanel]:NEEDS[TextureReplacer] { 
+@PART[1x3SPanels]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {}
+	%MODULE[TRReflection]
+      {
+        colour = 0.3 0.3 0.3
+		interval = 2
+		meshes = Panel1_002 Panel1_001 Panel1_004
+      }
+}
+@PART[largeSolarPanel]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -158,7 +178,8 @@
 		meshes = Panels
       }
 }
-@PART[spotLight1]:NEEDS[TextureReplacer] { 
+@PART[spotLight1]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -166,7 +187,8 @@
         meshes = Glass
       }
 }
-@PART[spotLight2]:NEEDS[TextureReplacer] { 
+@PART[spotLight2]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -174,7 +196,8 @@
         meshes = Glass
       }
 }
-@PART[sensorThermometer]:NEEDS[TextureReplacer] { 
+@PART[sensorThermometer]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -182,7 +205,8 @@
         meshes = glass
       }
 }
-@PART[liquidEngine3]:NEEDS[TextureReplacer] { 
+@PART[liquidEngine3]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -190,7 +214,8 @@
         meshes = Torus_001
       }
 }
-@PART[LargeOMS]:NEEDS[TextureReplacer] { 
+@PART[LargeOMS]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.1 0.1 0.1
@@ -198,7 +223,8 @@
 		meshes = Nozzle
       }
 }
-@PART[landerCabinSmall]:NEEDS[TextureReplacer] { 
+@PART[landerCabinSmall]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3
@@ -206,7 +232,8 @@
 		meshes = Shine
       }
 }
-@PART[cupola]:NEEDS[TextureReplacer] { 
+@PART[cupola]:NEEDS[TextureReplacer]:FINAL {
+	!MODULE[TRReflection],* {} 
 	%MODULE[TRReflection]
       {
         colour = 0.3 0.3 0.3


### PR DESCRIPTION
This prevents mods like [WindowShine](http://forum.kerbalspaceprogram.com/threads/122259-WindowShine-v-6-Hotfix-Reflective-stock-windows-and-solar-panels-5-21-15) that expect the base models from breaking the TR reflections.