### PR TITLE
Fix bad path from Communotron 16 model move.

### DIFF
--- a/GameData/VenStockRevamp/PathPatches/Utility-PathPatches.cfg
+++ b/GameData/VenStockRevamp/PathPatches/Utility-PathPatches.cfg
@@ -39,7 +39,7 @@
 		@model ^= :^Squad/Parts/Aero/cones/AvioCone:VenStockRevamp/Squad/Parts/ScienceParts/AVI:
 	}
 	@MODEL,* {
-		@model ^= :^Squad/Parts/Utility/commsDish16/model:VenStockRevamp/Squad/Parts/ScienceParts/commsDish16/model:
+		@model ^= :^Squad/Parts/Utility/commsDish16/model:VenStockRevamp/Squad/Parts/ScienceParts/16:
 	}
 	@MODEL,* {
 		@model ^= :^Squad/Parts/Science/sensorAccelerometer/model:VenStockRevamp/Squad/Parts/ScienceParts/ACC:


### PR DESCRIPTION
Fixes the Module Manager patch that adjusts the Communotron 16's model.  Breaks RemoteTech's Communotron 32 currently.