### PR TITLE
Corrected Mk26 Parachute ModuleDragModifier

### DIFF
--- a/GameData/VenStockRevamp/Part Bin/ExtraParachutes.cfg
+++ b/GameData/VenStockRevamp/Part Bin/ExtraParachutes.cfg
@@ -36,13 +36,14 @@
 	@chuteThermalMassPerArea = 0.08
     }
 	!MODULE[ModuleDragModifier]{}
-	@MODULE[ModuleDragModifier]
+	!MODULE[ModuleDragModifier]{}
+	MODULE
 	{
 		name = ModuleDragModifier
 		dragCubeName = SEMIDEPLOYED
 		dragModifier = 0.2
 	}
-	MODULE[ModuleDragModifier]
+	MODULE
 	{
 		name = ModuleDragModifier
 		dragCubeName = DEPLOYED


### PR DESCRIPTION
Squad:
	MODULE
	{
		name = ModuleDragModifier
		dragCubeName = SEMIDEPLOYED
		dragModifier = 0.33
	}
	MODULE
	{
		name = ModuleDragModifier
		dragCubeName = DEPLOYED
		dragModifier = 12
	}

Ven:
		MODULE
		{
			name = ModuleDragModifier
			dragCubeName = DEPLOYED
			dragModifier = 12
			name = ModuleDragModifier
			dragCubeName = SEMIDEPLOYED
			dragModifier = 0.2
		}
		MODULE[ModuleDragModifier]
		{
			name = ModuleDragModifier
			dragCubeName = DEPLOYED
			dragModifier = 5
		}


Khr15714n:
		MODULE
		{
			name = ModuleDragModifier
			dragCubeName = SEMIDEPLOYED
			dragModifier = 0.2
		}
		MODULE
		{
			name = ModuleDragModifier
			dragCubeName = DEPLOYED
			dragModifier = 5
		}

----------------------------

	@MODULE[ModuleDragModifier]	
	{
		@dragModifier = 0.2
	}
	@MODULE[ModuleDragModifier],1
	{
		@dragModifier = 5
	}

would be sufficient but adding the missing second delete fits to your style used in Utility.cfg