### PR TITLE
Duplicate entry for "fuelTank4-2" removed because it was causing the model to load twice.

### DIFF
--- a/GameData/VenStockRevamp/Squad/Parts/FuelTanks.cfg
+++ b/GameData/VenStockRevamp/Squad/Parts/FuelTanks.cfg
@@ -98,14 +98,6 @@
 	@attachRules = 1,1,1,1,0
 	%rescaleFactor = 1
 }
-@PART[fuelTank4-2] {
-	!mesh = DELETE
-    %scale = 1
-    %rescaleFactor = 1
-    MODEL {
-        model = VenStockRevamp/Squad/Parts/Propulsion/X200-8
-	}
-}
 @PART[fuelTank2-2] {
 	!mesh = DELETE
     %scale = 1


### PR DESCRIPTION
There was a duplicate entry for the part "fuelTank4-2" that was causing z-fighting. This causes other mods such as "ColorCodedCans" who replace the texture with their own because the game will try to use both models. Removing the duplicate will fix that issue.