### PR TITLE
Made the ConnectedLivingSpaces Patch work.

### DIFF
--- a/GameData/VenStockRevamp/CLS-Patches.cfg
+++ b/GameData/VenStockRevamp/CLS-Patches.cfg
@@ -1,4 +1,4 @@
-@PART[KerbCan]:NEEDS[ModuleConnectedLivingSpace]
+@PART[KerbCan]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
 	{
@@ -6,7 +6,7 @@
 		passable = true
 	}
 }
-@PART[stationHubLarge]:NEEDS[ModuleConnectedLivingSpace]
+@PART[stationHubLarge]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
 	{
@@ -14,7 +14,7 @@
 		passable = true
 	}
 }
-@PART[ParaDockingPort]:NEEDS[ModuleConnectedLivingSpace]
+@PART[ParaDockingPort]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
 	{
@@ -22,7 +22,7 @@
 		passable = true
 	}
 }
-@PART[MK1Cargobay]:NEEDS[ModuleConnectedLivingSpace]
+@PART[MK1Cargobay]:NEEDS[ConnectedLivingSpace]
 {
     MODULE
 	{


### PR DESCRIPTION
Before there was the word "Module" in front of "ConnectedLivingSpace". Since the name of the mod in the ":NEEDS" tab was wrong, it never actually did anything. This change addresses that issue.