### PR TITLE
Fixed Science Junior Radial Attach Node

### DIFF
--- a/GameData/VenStockRevamp/Squad/Parts/Utility.cfg
+++ b/GameData/VenStockRevamp/Squad/Parts/Utility.cfg
@@ -336,8 +336,9 @@
 		scale = 1.0, 0.85, 1.0
 		position = 0.0,0.1,0.0
 	}
-	@node_stack_top = 0.0, .49, 0.0, 0.0, 1.0, 0.0
-	@node_stack_bottom = 0.0, -.41, 0.0, 0.0, -1.0, 0.0
+	@node_stack_top = 0.0, .545, 0.0, 0.0, 1.0, 0.0
+	@node_stack_bottom = 0.0, -.405, 0.0, 0.0, -1.0, 0.0
+	@node_attach = 0.0, 0.0, 0.613, 1.0, 0.0, -90.0, 1
 	%scale = 1
 	%rescaleFactor = 1
 	@MODULE[ModuleAnimateGeneric] {


### PR DESCRIPTION
Fixed the materials bay attach node as well as the top and bottom node to fix small spacing errors.