### PR TITLE
Correcting 'Para_Docking_Port's top stack node

### DIFF
--- a/GameData/VenStockRevamp/Part Bin/Para_Docking_Port.cfg
+++ b/GameData/VenStockRevamp/Part Bin/Para_Docking_Port.cfg
@@ -9,7 +9,7 @@ MODEL {
 	}
 rescaleFactor = 1
 
-node_stack_top = 0.0, 0.2828832, 0.0, 0.0, 1.0, 0.0, 1
+node_stack_top = 0.0, 0.225, 0.0, 0.0, 1.0, 0.0, 1
 node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 
 TechRequired = composites


### PR DESCRIPTION
The coordinates for the top stack node on the Y were incorrect; maybe grabbed from the location of the extended bumper. Reduced to 0,225 seems to be correct to get them lining up in the VAB correctly.