### PR TITLE
Provide 'flag' for parts to not get patched

### DIFF
--- a/GameData/VenStockRevamp/PathPatches/All-PathPatches.cfg
+++ b/GameData/VenStockRevamp/PathPatches/All-PathPatches.cfg
@@ -1,4 +1,4 @@
-@PART[*]:FOR[zzzVSRPathPatch] {
+@PART[*]:HAS[~VSRexclude[*rue]]:FOR[zzzVSRPathPatch] {
 	@MODEL,* {
 		@model ^= :^Squad/Parts/Aero/HeatShield/HeatShield0:VenStockRevamp/Squad/Parts/Heatshields/HeatShieldS0:
 		@model ^= :^Squad/Parts/Aero/HeatShield/HeatShield1:VenStockRevamp/Squad/Parts/Heatshields/HeatShieldS1:


### PR DESCRIPTION
Mod authors who want parts to use Squad models and not Revamp models can add a patch as follows:

```
@PART[whatever_parts]:BEFORE[zzzVSRPathPatch]
{
	VSRexclude = true
}
```
Then this patch will skip over them.